### PR TITLE
Keychain: Added Codable support

### DIFF
--- a/Example/Tests/Specs/Keychain/KeychainSpec.swift
+++ b/Example/Tests/Specs/Keychain/KeychainSpec.swift
@@ -14,6 +14,7 @@ import Keychain
 // Define the keys used for this test.
 extension Keys {
     static let stringValue = Key<String?>("stringValue")
+    static let codableValue = Key<String?>("codableValue")
 }
 
 private struct TestCodable: Codable, Equatable {
@@ -52,8 +53,8 @@ class KeychainSpec: QuickSpec {
                 it("should be able to write a codable value to the keychain") {
                     let value = TestCodable(identifier: "123",
                                             timestamp: Date(timeIntervalSince1970: 2000))
-                    keychain[.testKey] = value
-                    expect(keychain[.testKey]) == value
+                    Keychain[.codableValue] = value
+                    expect(Keychain[.codableValue]) == value
                 }
 
                 it("Should override a codable value to the keychain") {
@@ -61,20 +62,20 @@ class KeychainSpec: QuickSpec {
                                              timestamp: Date(timeIntervalSince1970: 2000))
                     let value2 = TestCodable(identifier: "456",
                                              timestamp: Date(timeIntervalSince1970: 3000))
-                    keychain[.testKey] = value1
-                    keychain[.testKey] = value2
+                    Keychain[.codableValue] = value1
+                    Keychain[.codableValue] = value2
 
-                    expect(keychain[.testKey]) == value2
+                    expect(Keychain[.codableValue]) == value2
                 }
 
                 it("should be able to delete a codable value from the keychain") {
                     let value = TestCodable(identifier: "123",
                                             timestamp: Date(timeIntervalSince1970: 2000))
-                    keychain[.testKey] = value
-                    expect(keychain[.testKey]).toNot(beNil())
+                    Keychain[.codableValue] = value
+                    expect(Keychain[.codableValue]).toNot(beNil())
 
-                    keychain[.testKey] = nil
-                    expect(keychain[.testKey]).to(beNil())
+                    Keychain[.codableValue] = nil
+                    expect(Keychain[.codableValue]).to(beNil())
                 }
             }
         }

--- a/Example/Tests/Specs/Keychain/KeychainSpec.swift
+++ b/Example/Tests/Specs/Keychain/KeychainSpec.swift
@@ -17,10 +17,10 @@ extension Keys {
 }
 
 private struct TestCodable: Codable, Equatable {
-    var id: String
+    var identifier: String
     var timestamp: Date
-    init(id: String, timestamp: Date) {
-        self.id = id
+    init(identifier: String, timestamp: Date) {
+        self.identifier = identifier
         self.timestamp = timestamp
     }
 }
@@ -50,16 +50,16 @@ class KeychainSpec: QuickSpec {
                 }
 
                 it("should be able to write a codable value to the keychain") {
-                    let value = TestCodable(id: "123",
+                    let value = TestCodable(identifier: "123",
                                             timestamp: Date(timeIntervalSince1970: 2000))
                     keychain[.testKey] = value
                     expect(keychain[.testKey]) == value
                 }
 
                 it("Should override a codable value to the keychain") {
-                    let value1 = TestCodable(id: "123",
+                    let value1 = TestCodable(identifier: "123",
                                              timestamp: Date(timeIntervalSince1970: 2000))
-                    let value2 = TestCodable(id: "456",
+                    let value2 = TestCodable(identifier: "456",
                                              timestamp: Date(timeIntervalSince1970: 3000))
                     keychain[.testKey] = value1
                     keychain[.testKey] = value2
@@ -68,7 +68,7 @@ class KeychainSpec: QuickSpec {
                 }
 
                 it("should be able to delete a codable value from the keychain") {
-                    let value = TestCodable(id: "123",
+                    let value = TestCodable(identifier: "123",
                                             timestamp: Date(timeIntervalSince1970: 2000))
                     keychain[.testKey] = value
                     expect(keychain[.testKey]).toNot(beNil())

--- a/Example/Tests/Specs/Keychain/KeychainSpec.swift
+++ b/Example/Tests/Specs/Keychain/KeychainSpec.swift
@@ -16,6 +16,15 @@ extension Keys {
     static let stringValue = Key<String?>("stringValue")
 }
 
+private struct TestCodable: Codable, Equatable {
+    var id: String
+    var timestamp: Date
+    init(id: String, timestamp: Date) {
+        self.id = id
+        self.timestamp = timestamp
+    }
+}
+
 class KeychainSpec: QuickSpec {
     override func spec() {
         describe("keychain") {
@@ -38,6 +47,34 @@ class KeychainSpec: QuickSpec {
                 it("should be able to read to the keychain") {
                     _ = Keychain.save("Some string value", forKey: "stringValue")
                     expect(Keychain[.stringValue]).to(equal("Some string value"))
+                }
+
+                it("should be able to write a codable value to the keychain") {
+                    let value = TestCodable(id: "123",
+                                            timestamp: Date(timeIntervalSince1970: 2000))
+                    keychain[.testKey] = value
+                    expect(keychain[.testKey]) == value
+                }
+
+                it("Should override a codable value to the keychain") {
+                    let value1 = TestCodable(id: "123",
+                                             timestamp: Date(timeIntervalSince1970: 2000))
+                    let value2 = TestCodable(id: "456",
+                                             timestamp: Date(timeIntervalSince1970: 3000))
+                    keychain[.testKey] = value1
+                    keychain[.testKey] = value2
+
+                    expect(keychain[.testKey]) == value2
+                }
+
+                it("should be able to delete a codable value from the keychain") {
+                    let value = TestCodable(id: "123",
+                                            timestamp: Date(timeIntervalSince1970: 2000))
+                    keychain[.testKey] = value
+                    expect(keychain[.testKey]).toNot(beNil())
+
+                    keychain[.testKey] = nil
+                    expect(keychain[.testKey]).to(beNil())
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -131,10 +131,16 @@ extension Keys {
 ```
 
 You can read/write the from/to the `Keychain` by using the `subscript` on the `Keychain` class.
+It supports both regular `String` values as well as `Codable` objects.
 
 ```swift
 Keychain[.stringValue] = "A string value"
 print(Keychain[.stringValue]) // Prints 'A string value'
+
+```swift
+Keychain[.codableValue] = ClassConformingToCodable()
+print(Keychain[.codableValue]) // Prints '<ClassConformingToCodable: 0x0123456789>'
+```
 ```
 
 In some cases you want to be able to set additional keychain query paramaters on an item.


### PR DESCRIPTION
1. Renamed incorrectly named 'bundleIdentifier' to 'serviceIdentifier' + added deprecation warning.
2. Added Codable support for Keychain.